### PR TITLE
[Feature] Removed default title

### DIFF
--- a/packages/cli/app/index.html
+++ b/packages/cli/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Capsulahub application</title>
+    <title></title>
   </head>
   <body>
     <div id="capsulahub-root"></div>


### PR DESCRIPTION
In order to give the ability to users to set their own app title, removing the default title will avoid a blink with `CapsulaHub Application` in the user app.